### PR TITLE
feat: add support for basic codeowners-like file configuration

### DIFF
--- a/__tests__/fixtures/CODEMENTION
+++ b/__tests__/fixtures/CODEMENTION
@@ -1,0 +1,4 @@
+/config            @sysadmin
+/db/migrate        @cto @dba
+/.github           @ci
+/spec/*.rb         @ci

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -7,7 +7,7 @@ import {randomUUID} from 'crypto'
 import {Mock} from 'moq.ts'
 
 import {CommentUpserterImpl} from '../src/comment-upserter'
-import {ConfigurationReaderImpl} from '../src/configuration-reader'
+import {CodementionCodeownersLikeFormatFileConfigurationReaderImpl, CodementionYamlConfigurationReaderImpl} from '../src/configuration-reader'
 import {FilesChangedReaderImpl} from '../src/files-changed-reader'
 import {run} from '../src/main'
 import Runner from '../src/runner'
@@ -26,14 +26,6 @@ describe('run', () => {
   let octokitRest: RestEndpointMethods
 
   beforeEach(() => {
-    jest.mocked(core).getInput.mockImplementation(input => {
-      if (input === 'githubToken') {
-        return githubToken
-      } else {
-        throw new Error(`Unexpected input: ${input}`)
-      }
-    })
-
     octokitRest = new Mock<RestEndpointMethods>().object()
     octokit = new Mock<InstanceType<typeof GitHub>>()
       .setup(instance => instance.rest)
@@ -43,17 +35,59 @@ describe('run', () => {
   })
 
   it('calls Runner.run', async () => {
+    jest.mocked(core).getInput.mockImplementation(input => {
+      if (input === 'githubToken') {
+        return githubToken
+      } else if (input === 'configFileType') {
+        return 'yaml'
+      } else {
+        throw new Error(`Unexpected input: ${input}`)
+      }
+    })
+
     await run()
 
     expect(github.getOctokit).toHaveBeenCalledWith(githubToken)
-    expect(jest.mocked(ConfigurationReaderImpl)).toHaveBeenCalledWith(
+    expect(jest.mocked(CodementionYamlConfigurationReaderImpl)).toHaveBeenCalledWith(
       octokitRest
     )
     expect(jest.mocked(FilesChangedReaderImpl)).toHaveBeenCalledWith(octokit)
     expect(jest.mocked(CommentUpserterImpl)).toHaveBeenCalledWith(octokitRest)
 
     expect(jest.mocked(Runner)).toHaveBeenCalledWith(
-      jest.mocked(ConfigurationReaderImpl).mock.instances[0],
+      jest.mocked(CodementionYamlConfigurationReaderImpl).mock.instances[0],
+      jest.mocked(FilesChangedReaderImpl).mock.instances[0],
+      jest.mocked(CommentUpserterImpl).mock.instances[0]
+    )
+
+    expect(jest.mocked(Runner).mock.instances[0].run).toHaveBeenCalledWith(
+      github.context
+    )
+    expect(jest.mocked(core).setFailed).not.toHaveBeenCalled()
+  })
+
+  it('supports codeowners-like file format', async () => {
+    jest.mocked(core).getInput.mockImplementation(input => {
+      if (input === 'githubToken') {
+        return githubToken
+      } else if (input === 'configFileType') {
+        return 'codeowners-like'
+      } else {
+        throw new Error(`Unexpected input: ${input}`)
+      }
+    })
+
+    await run()
+
+    expect(github.getOctokit).toHaveBeenCalledWith(githubToken)
+    expect(jest.mocked(CodementionCodeownersLikeFormatFileConfigurationReaderImpl)).toHaveBeenCalledWith(
+      octokitRest
+    )
+    expect(jest.mocked(FilesChangedReaderImpl)).toHaveBeenCalledWith(octokit)
+    expect(jest.mocked(CommentUpserterImpl)).toHaveBeenCalledWith(octokitRest)
+
+    expect(jest.mocked(Runner)).toHaveBeenCalledWith(
+      jest.mocked(CodementionCodeownersLikeFormatFileConfigurationReaderImpl).mock.instances[0],
       jest.mocked(FilesChangedReaderImpl).mock.instances[0],
       jest.mocked(CommentUpserterImpl).mock.instances[0]
     )

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
   githubToken:
     required: true
     description: GitHub API token
+  configFileType:
+    required: false
+    description: Type of config file to use
+    default: yaml
 
 runs:
   using: composite

--- a/src/configuration-reader.ts
+++ b/src/configuration-reader.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import {RestEndpointMethods} from '@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types.d'
 import * as yaml from 'js-yaml'
 
-import {Configuration} from './configuration'
+import {Configuration, MentionRule} from './configuration'
 import {Repo} from './github-types'
 
 /**
@@ -19,7 +19,9 @@ export interface ConfigurationReader {
   read(repo: Repo, ref: string): Promise<Configuration>
 }
 
-export class ConfigurationReaderImpl implements ConfigurationReader {
+export class CodementionYamlConfigurationReaderImpl
+  implements ConfigurationReader
+{
   /**
    * @param octokitRest - GitHub REST API client
    */
@@ -39,5 +41,69 @@ export class ConfigurationReaderImpl implements ConfigurationReader {
       return yaml.load(content) as Configuration
     }
     throw new Error('No content for .github/codemention.yml')
+  }
+}
+
+export class CodementionCodeownersLikeFormatFileConfigurationReaderImpl
+  implements ConfigurationReader
+{
+  /**
+   * @param octokitRest - GitHub REST API client
+   */
+  constructor(private readonly octokitRest: RestEndpointMethods) {}
+
+  /** @override */
+  async read(repo: Repo, ref: string): Promise<Configuration> {
+    core.debug(`Reading CODEMENTION on ${ref}`)
+    const {data} = await this.octokitRest.repos.getContent({
+      owner: repo.owner,
+      repo: repo.repo,
+      path: '.github/CODEMENTION',
+      ref
+    })
+    if ('content' in data) {
+      const content = Buffer.from(data.content, 'base64').toString()
+      return CodementionCodeownersLikeFormatFileConfigurationReaderImpl.parseCodeownersLikeFile(
+        content
+      )
+    }
+    throw new Error('No content for .github/CODEMENTION')
+  }
+
+  private static parseCodeownersLikeFile(fileContent: string): Configuration {
+    const filteredFileLines = fileContent
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => !!line)
+      .filter(line => !line.startsWith('#'))
+
+    if (filteredFileLines.some(line => line.startsWith('!'))) {
+      throw new Error('Unsupported negation in CODEMENTION: `!`')
+    }
+
+    return {
+      rules: filteredFileLines.map(line =>
+        this.parseCodeownersLikeFileLine(line)
+      )
+    }
+  }
+
+  private static parseCodeownersLikeFileLine(line: string): MentionRule {
+    const lineParts = line
+      .split(/(?<!\\)\s/)
+      .map(part => part.trim())
+      .filter(part => !!part)
+    if (lineParts.length < 2) {
+      throw new Error(
+        `Unsupported line in CODEMENTION, must have a path and at least one author: ${line}`
+      )
+    }
+
+    const [pattern, ...mentions] = lineParts
+
+    return {
+      patterns: [pattern],
+      mentions: mentions.map(mention => mention.replace('@', ''))
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,17 +2,32 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import {CommentUpserterImpl} from './comment-upserter'
-import {ConfigurationReaderImpl} from './configuration-reader'
+import {
+  CodementionCodeownersLikeFormatFileConfigurationReaderImpl,
+  CodementionYamlConfigurationReaderImpl
+} from './configuration-reader'
 import {FilesChangedReaderImpl} from './files-changed-reader'
 import Runner from './runner'
 
 export async function run(): Promise<void> {
   try {
     const githubToken = core.getInput('githubToken')
+    const configFileType = core.getInput('configFileType')
+    if (!['yaml', 'codeowners-like'].includes(configFileType)) {
+      throw new Error(
+        'Invalid configFileType. Must be either "yaml" or "codeowners-like"'
+      )
+    }
+
     const octokit = github.getOctokit(githubToken)
     const octokitRest = octokit.rest
 
-    const configurationReader = new ConfigurationReaderImpl(octokitRest)
+    const configurationReader =
+      configFileType === 'yaml'
+        ? new CodementionYamlConfigurationReaderImpl(octokitRest)
+        : new CodementionCodeownersLikeFormatFileConfigurationReaderImpl(
+            octokitRest
+          )
     const filesChangedReader = new FilesChangedReaderImpl(octokit)
     const commentUpserter = new CommentUpserterImpl(octokitRest)
     const runner = new Runner(


### PR DESCRIPTION
To ease the migration from CODEOWNERS, this PR adds support for reading configuration from basic CODEOWNERS files.

It only supports affirmative (no `!`).