### PR TITLE
feat: add ability to set custom comment content

### DIFF
--- a/__tests__/fixtures/codemention.yml
+++ b/__tests__/fixtures/codemention.yml
@@ -1,3 +1,6 @@
+commentConfiguration:
+  preamble: 'testing preamble'
+  epilogue: 'testing epilogue'
 rules:
   - patterns: ['config/**']
     mentions: ['sysadmin']

--- a/__tests__/runner.test.ts
+++ b/__tests__/runner.test.ts
@@ -97,7 +97,7 @@ describe('Runner', () => {
         }
       ]
       commentUpserterMock.verify(instance =>
-        instance.upsert(repo, prNumber, matchingRules)
+        instance.upsert(repo, prNumber, matchingRules, {preamble: 'testing preamble', epilogue: 'testing epilogue'})
       )
     })
   })

--- a/src/comment-upserter.ts
+++ b/src/comment-upserter.ts
@@ -20,7 +20,7 @@ export interface CommentUpserter {
    * @param repo - repository that the pull request is in
    * @param pullNumber - number that identifies the pull request
    * @param rules - mention rules to use in the comment
-   * @param commentContent - comment content to print above matching rules table
+   * @param commentConfiguration - comment configuration for the upserted comment
    */
   upsert(
     repo: Repo,
@@ -81,7 +81,7 @@ export class CommentUpserterImpl implements CommentUpserter {
 
   /**
    * @param rules - mention rules to use in the comment
-   * @param commentContent - comment content to print above matching rules table
+   * @param commentConfiguration - comment configuration for the upserted comment
    * @returns text to be used in a GitHub pull request comment body
    */
   private createCommentBody(

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,9 +10,21 @@ export interface MentionRule {
 }
 
 /**
+ * A set of configuration items for the comment posted by the bot
+ */
+export interface CommentConfiguration {
+  /** Comment content to print above matching rules table */
+  preamble?: string
+  /** Comment content to print below matching rules table */
+  epilogue?: string
+}
+
+/**
  * Configuration for the GitHub Action
  */
 export interface Configuration {
   /** Rules for mentioning */
   rules: MentionRule[]
+  /** Configuration for comment */
+  commentConfiguration?: CommentConfiguration
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -36,17 +36,18 @@ export default class Runner {
       return
     }
 
-    const configuration = await this.configurationReader.read(
-      repo,
-      pullRequest.base.sha
-    )
-    const filesChanged = await this.filesChangedReader.read(
-      repo,
-      pullRequest.number
-    )
+    const [configuration, filesChanged] = await Promise.all([
+      this.configurationReader.read(repo, pullRequest.base.sha),
+      this.filesChangedReader.read(repo, pullRequest.number)
+    ])
     const matchingRules = configuration.rules.filter(
       rule => micromatch(filesChanged, rule.patterns).length > 0
     )
-    await this.commentUpserter.upsert(repo, pullRequest.number, matchingRules)
+    await this.commentUpserter.upsert(
+      repo,
+      pullRequest.number,
+      matchingRules,
+      configuration.commentConfiguration
+    )
   }
 }


### PR DESCRIPTION
# Why

For mobile notifications that have limited space, the default comment content doesn't optimize for information density. This PR allows overriding the default attribution link. Attribution to the original repo is useful, though, so this PR also allows supplying a custom footer so one can specify the attribution to be posted there (maybe even link to the action itself) (we do something like this in the expo github action: https://github.com/expo/expo-github-action/blob/8108b8660bffafbf7b8132b1b108219f2269f2a0/src/actions/preview.ts#L207)

# How

Add configuration value to allow overriding the default preamble and epilogue of the comment content.

# Test Plan

Run all tests (updated to test this configuration).