### PR TITLE
fix: re-add newline after header to make link render correctly

### DIFF
--- a/__tests__/comment-upserter.test.ts
+++ b/__tests__/comment-upserter.test.ts
@@ -68,8 +68,8 @@ describe('CommentUpserterImpl', () => {
 
       it('creates a comment', async () => {
         const expectedCommentBody =
-          HEADER +
           [
+            HEADER,
             DEFAULT_COMMENT_PREAMBLE,
             '| File Patterns | Mentions |',
             '| - | - |',
@@ -102,8 +102,8 @@ describe('CommentUpserterImpl', () => {
           epilogue: '> [CodeMention](https://github.com/tobyhs/codemention)'
         }
         const expectedCommentBody =
-          HEADER +
           [
+            HEADER,
             customContent.preamble,
             '| File Patterns | Mentions |',
             '| - | - |',
@@ -136,8 +136,8 @@ describe('CommentUpserterImpl', () => {
       describe('and the comment is different', () => {
         it('updates the comment', async () => {
           const expectedCommentBody =
-          HEADER +
           [
+            HEADER,
             DEFAULT_COMMENT_PREAMBLE,
             '| File Patterns | Mentions |',
             '| - | - |',
@@ -171,8 +171,8 @@ describe('CommentUpserterImpl', () => {
       describe('and the comment is the same', () => {
         it('does not update the comment', async () => {
           const commentBody =
-          HEADER +
           [
+            HEADER,
             DEFAULT_COMMENT_PREAMBLE,
             '| File Patterns | Mentions |',
             '| - | - |',

--- a/src/comment-upserter.ts
+++ b/src/comment-upserter.ts
@@ -95,7 +95,8 @@ export class CommentUpserterImpl implements CommentUpserter {
       const mentions = rule.mentions.map(name => `@${name}`).join(', ')
       return `| ${patterns} | ${mentions} |`
     })
-    const content = [
+    return [
+      HEADER,
       commentConfiguration?.preamble ?? DEFAULT_COMMENT_PREAMBLE,
       '| File Patterns | Mentions |',
       '| - | - |',
@@ -106,6 +107,5 @@ export class CommentUpserterImpl implements CommentUpserter {
     ]
       .filter(elem => elem !== undefined)
       .join('\n')
-    return `${HEADER}${content}`
   }
 }


### PR DESCRIPTION
# Why

Fix for issue found after full e2e testing of https://github.com/tobyhs/codemention/pull/15.

https://github.com/tobyhs/codemention/pull/15#discussion_r1791158009

# How

My guess is that it has to do with the newline character. In a follow-up, I'll investigate changing the sentinel HEADER to be a FOOTER to avoid this and avoid the issue removing the newline character was trying to solve.

# Test Plan

Edit a codemention comment on another PR and remove the newline, see the symptoms. Re-add the newline, see it is fixed.