### PR TITLE
fix: move codemention sentinel to end of comment

### DIFF
--- a/__tests__/comment-upserter.test.ts
+++ b/__tests__/comment-upserter.test.ts
@@ -3,7 +3,7 @@ import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods'
 import {RestEndpointMethods} from '@octokit/plugin-rest-endpoint-methods/dist-types/generated/method-types.d'
 import {EqualMatchingInjectorConfig, It, Mock, Times} from 'moq.ts'
 
-import {CommentUpserterImpl, DEFAULT_COMMENT_PREAMBLE, HEADER} from '../src/comment-upserter'
+import {CommentUpserterImpl, DEFAULT_COMMENT_PREAMBLE, FOOTER} from '../src/comment-upserter'
 import {Repo} from '../src/github-types'
 
 describe('CommentUpserterImpl', () => {
@@ -69,12 +69,13 @@ describe('CommentUpserterImpl', () => {
       it('creates a comment', async () => {
         const expectedCommentBody =
           [
-            HEADER,
             DEFAULT_COMMENT_PREAMBLE,
             '| File Patterns | Mentions |',
             '| - | - |',
             '| db/migrate/\\*\\* | @cto, @dba |',
-            '| .github/\\*\\*<br>spec/\\*.rb | @ci |'
+            '| .github/\\*\\*<br>spec/\\*.rb | @ci |',
+            '',
+            FOOTER
           ].join('\n')
 
         issuesMock
@@ -103,13 +104,14 @@ describe('CommentUpserterImpl', () => {
         }
         const expectedCommentBody =
           [
-            HEADER,
             customContent.preamble,
             '| File Patterns | Mentions |',
             '| - | - |',
             '| db/migrate/\\*\\* | @cto, @dba |',
             '| .github/\\*\\*<br>spec/\\*.rb | @ci |',
-            `\n${customContent.epilogue}`
+            '',
+            customContent.epilogue,
+            FOOTER
           ].join('\n')
 
         issuesMock
@@ -134,37 +136,77 @@ describe('CommentUpserterImpl', () => {
 
     describe('when a codemention comment exists', () => {
       describe('and the comment is different', () => {
-        it('updates the comment', async () => {
-          const expectedCommentBody =
-          [
-            HEADER,
-            DEFAULT_COMMENT_PREAMBLE,
-            '| File Patterns | Mentions |',
-            '| - | - |',
-            '| db/migrate/\\*\\* | @cto, @dba |',
-            '| .github/\\*\\*<br>spec/\\*.rb | @ci |'
-          ].join('\n')
+        describe('and the comment has the sentinel at the start', () => {
+          it('updates the comment', async () => {
+            const expectedCommentBody =
+            [
+              DEFAULT_COMMENT_PREAMBLE,
+              '| File Patterns | Mentions |',
+              '| - | - |',
+              '| db/migrate/\\*\\* | @cto, @dba |',
+              '| .github/\\*\\*<br>spec/\\*.rb | @ci |',
+              '',
+              FOOTER,
+            ].join('\n')
 
-          const existingComment = HEADER + '| config/brakeman.yml | @security |'
-          stubListComments(['First', existingComment])
+            // previous version of the action put the sentinel comment at the start
+            const existingComment = FOOTER + '| config/brakeman.yml | @security |'
+            stubListComments(['First', existingComment])
 
-          issuesMock
-            .setup(instance => instance.updateComment(It.IsAny()))
-            .returnsAsync(
-              new Mock<
-                RestEndpointMethodTypes['issues']['updateComment']['response']
-              >().object()
+            issuesMock
+              .setup(instance => instance.updateComment(It.IsAny()))
+              .returnsAsync(
+                new Mock<
+                  RestEndpointMethodTypes['issues']['updateComment']['response']
+                >().object()
+              )
+
+            await upserter.upsert(repo, pullNumber, rules)
+
+            issuesMock.verify(instance =>
+              instance.updateComment({
+                ...repo,
+                comment_id: 2,
+                body: expectedCommentBody
+              })
             )
+          })
+        })
 
-          await upserter.upsert(repo, pullNumber, rules)
+        describe('and the comment has the sentinel at the end', () => {
+          it('updates the comment', async () => {
+            const expectedCommentBody =
+            [
+              DEFAULT_COMMENT_PREAMBLE,
+              '| File Patterns | Mentions |',
+              '| - | - |',
+              '| db/migrate/\\*\\* | @cto, @dba |',
+              '| .github/\\*\\*<br>spec/\\*.rb | @ci |',
+              '',
+              FOOTER,
+            ].join('\n')
 
-          issuesMock.verify(instance =>
-            instance.updateComment({
-              ...repo,
-              comment_id: 2,
-              body: expectedCommentBody
-            })
-          )
+            const existingComment = '| config/brakeman.yml | @security |' + FOOTER
+            stubListComments(['First', existingComment])
+
+            issuesMock
+              .setup(instance => instance.updateComment(It.IsAny()))
+              .returnsAsync(
+                new Mock<
+                  RestEndpointMethodTypes['issues']['updateComment']['response']
+                >().object()
+              )
+
+            await upserter.upsert(repo, pullNumber, rules)
+
+            issuesMock.verify(instance =>
+              instance.updateComment({
+                ...repo,
+                comment_id: 2,
+                body: expectedCommentBody
+              })
+            )
+          })
         })
       })
 
@@ -172,12 +214,13 @@ describe('CommentUpserterImpl', () => {
         it('does not update the comment', async () => {
           const commentBody =
           [
-            HEADER,
             DEFAULT_COMMENT_PREAMBLE,
             '| File Patterns | Mentions |',
             '| - | - |',
             '| db/migrate/\\*\\* | @cto, @dba |',
-            '| .github/\\*\\*<br>spec/\\*.rb | @ci |'
+            '| .github/\\*\\*<br>spec/\\*.rb | @ci |',
+            '',
+            FOOTER
           ].join('\n')
 
           stubListComments(['First', commentBody])


### PR DESCRIPTION
# Why

https://github.com/tobyhs/codemention/pull/15 removed the newline after the sentinel in an effort to make mobile notifications better.

It seemed to cause the link to not render in the preamble: https://github.com/tobyhs/codemention/pull/15#discussion_r1791158009

https://github.com/tobyhs/codemention/pull/16 reverted that piece to get the main branch back to a working state.

# How

Looking at other libraries like Graphite, it seems to put the sentinel at the end. No way to know if this is by coincidence, but my guess is that it'll work well.

# Test Plan

Run all tests.

Also ran as part of https://github.com/expo/codemention/pull/1.

Tested in fork to see if newline was in fact what was causing it, and it was! Verified this PR fixes it.

![IMG_4330](https://github.com/user-attachments/assets/eb2a61b7-652e-47ba-af30-f6414e7a4f84)
