### PR TITLE
Avoid copying action into workspace when they are the same

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,9 @@ runs:
     # because some things don't work outside the workspace (actions/setup-node
     # resolves the node-version-file input relative to the workspace; hashFiles
     # only works on files inside the workspace).
-    - run: cp -r "${{ github.action_path }}/." .
+    - name: Copy action into workspace
+      run: |
+        [ "$(realpath '${{ github.action_path }}')" = "$(realpath '${{ github.workspace }}')" ] || cp -r "${{ github.action_path }}/." .
       shell: bash
     - uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
This fixes a bug in bd5d40b6881b888401126efc09a34367a115a319 that I believe only affects codemention itself. When the codemention repo uses itself, the action path directory is the same as the workspace directory, so the `cp` invocation fails.